### PR TITLE
feat: 키워드 기반 AI 뉴스 조회 API 연결

### DIFF
--- a/newspace-frontend/package-lock.json
+++ b/newspace-frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "newspace-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.7.9",
         "lucide-react": "^0.475.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -1616,6 +1617,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1630,6 +1637,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -1706,7 +1724,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1809,6 +1826,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1989,6 +2018,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -2006,7 +2044,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2094,7 +2131,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2104,7 +2140,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2142,7 +2177,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2155,7 +2189,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2544,6 +2577,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -2558,6 +2611,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fsevents": {
@@ -2579,7 +2647,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2630,7 +2697,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
       "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2655,7 +2721,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -2730,7 +2795,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2795,7 +2859,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2808,7 +2871,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -2824,7 +2886,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3451,10 +3512,30 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -3796,6 +3877,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -4444,14 +4531,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "license": "0BSD"
     },
-
     "node_modules/turbo-stream": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",

--- a/newspace-frontend/package.json
+++ b/newspace-frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.7.9",
     "lucide-react": "^0.475.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/newspace-frontend/src/api/newsApi.jsx
+++ b/newspace-frontend/src/api/newsApi.jsx
@@ -1,0 +1,18 @@
+import axios from "axios";
+
+const BASE_URL = `${import.meta.env.VITE_NEWSPACE_TEST_BACKEND_URL}`.replace(/\/$/, '') + "/api/news";
+
+// 특정 키워드에 해당하는 뉴스 목록을 가져오는 함수
+export const fetchNewsByCategory = async (keyword) => {
+    try {
+        const url = `${BASE_URL}?keyword=${encodeURIComponent(keyword)}`;
+        console.log("API 요청 URL:", url); 
+
+        const response = await axios.get(url);
+        return response.data; // 뉴스 목록 반환
+    } catch (error) {
+        console.error("뉴스 데이터 불러오기 실패:", error);
+        throw error;
+    }
+};
+

--- a/newspace-frontend/src/pages/news/newsCategory.jsx
+++ b/newspace-frontend/src/pages/news/newsCategory.jsx
@@ -1,6 +1,8 @@
 import { useParams, Link} from "react-router-dom";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 
+import { fetchNewsByCategory } from "../../api/newsApi";
 
 import Sidebar from "./sidebar";
 
@@ -69,90 +71,27 @@ const TitleLink = styled(Link)`
 
 const NewsCategoryPage = () => {
     const { category } = useParams(); 
+    const [newsList, setNewsList] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
 
-    // 뉴스 더미 데이터
-    const newsList = [
-        {
-            id: 1,
-            title: "Fed Cuts Interest Rates to 2.5%",
-            content: "The Federal Reserve cut interest rates for the fifth time in six months, lowering the federal funds rate to 2.5%.",
-            date: "2002-02-21",
-            source: "The New York Times",
-            link: "https://www.nytimes.com/2002/02/21/business/fed-cuts-interest-rates-to-2.5.html"
-        },
-        { 
-            id: 2,
-            title: "Tech Giants Face Antitrust Scrutiny",
-            content: "Regulators in the US and EU are looking into whether major tech firms have engaged in anti-competitive behavior.",
-            date: "2024-02-20",
-            source: "BBC News",
-            link: "https://www.bbc.com/news/business-tech"
-        },
-        { 
-            id: 3,
-            title: "Global Markets Rally on Strong Earnings",
-            content: "Stock markets surged worldwide following better-than-expected earnings reports from leading companies.",
-            date: "2024-02-19",
-            source: "CNBC",
-            link: "https://www.cnbc.com/global-markets"
-        },
-        { 
-            id: 4,
-            title: "Climate Change Policies Under Debate",
-            content: "World leaders gather to discuss the future of climate change policies in a high-stakes summit.",
-            date: "2024-02-18",
-            source: "The Guardian",
-            link: "https://www.theguardian.com/environment/climate-policy"
-        },
-        {   
-            id: 5,
-            title: "AI Breakthrough in Medical Diagnosis",
-            content: "A new AI model has been developed that can detect diseases with higher accuracy than human doctors.",
-            date: "2024-02-17",
-            source: "MIT Technology Review",
-            link: "https://www.technologyreview.com/ai-medicine"
-        },
-        {   
-            id: 6,
-            title: "Electric Vehicles Sales Hit Record High",
-            content: "Sales of electric vehicles reached an all-time high last quarter, driven by government incentives and innovation.",
-            date: "2024-02-16",
-            source: "Bloomberg",
-            link: "https://www.bloomberg.com/ev-sales"
-        },
-        { 
-            id: 7,
-            title: "NASA Announces New Mars Mission",
-            content: "NASA has revealed plans for a new mission to explore potential signs of life on Mars.",
-            date: "2024-02-15",
-            source: "NASA",
-            link: "https://mars.nasa.gov/new-mission"
-        },
-        { 
-            id: 8,
-            title: "Cryptocurrency Market Sees Major Fluctuations",
-            content: "Bitcoin and Ethereum prices experienced significant volatility, prompting concerns among investors.",
-            date: "2024-02-14",
-            source: "CoinDesk",
-            link: "https://www.coindesk.com/crypto-market"
-        },
-        { 
-            id: 9,
-            title: "Major Cities Implement New Traffic Laws",
-            content: "Several global cities have introduced new regulations aimed at reducing traffic congestion and pollution.",
-            date: "2024-02-13",
-            source: "Reuters",
-            link: "https://www.reuters.com/traffic-laws"
-        },
-        { 
-            id: 10,
-            title: "Advances in Quantum Computing Announced",
-            content: "Scientists have made a breakthrough in quantum computing, bringing commercial applications closer to reality.",
-            date: "2024-02-12",
-            source: "Wired",
-            link: "https://www.wired.com/quantum-computing"
-        }
-    ];
+    useEffect(() => {
+        const fetchNews = async () => {
+            setLoading(true);
+            setError(null);
+            try {
+                const data = await fetchNewsByCategory(category); // API 호출
+                setNewsList(data); // 뉴스 리스트 상태 업데이트
+            } catch (error) {
+                setError("뉴스 데이터를 불러오는 중 오류가 발생했습니다.");
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchNews();
+    }, [category]); 
+    
 
     return (
         <>
@@ -160,6 +99,15 @@ const NewsCategoryPage = () => {
         <Container>
                 <Title>과거의 오늘 </Title>
                 <Title2>가장 많이 주목받은 <HighlightedText>{category}</HighlightedText> 뉴스</Title2>
+
+                {/* 로딩 중 표시 */}
+                {loading && <p>로딩 중...</p>}
+
+                {/* 에러 메시지 표시 */}
+                {error && <p style={{ color: "red" }}>{error}</p>}
+
+                {/* 뉴스 목록 출력 */}
+                {!loading && !error && newsList.length > 0 ? (
                 <NewsTable>
                     <thead>
                         <tr>
@@ -182,6 +130,9 @@ const NewsCategoryPage = () => {
                         ))}
                     </tbody>
                 </NewsTable>
+                ) : (
+                    !loading && !error && <p>해당 카테고리의 뉴스가 없습니다.</p>
+                )}
             </Container>
         </>
     );

--- a/newspace-frontend/src/pages/news/newsDetail.jsx
+++ b/newspace-frontend/src/pages/news/newsDetail.jsx
@@ -1,6 +1,8 @@
-import { useParams, Link} from "react-router-dom";
+import { useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 
+import { fetchNewsByCategory } from "../../api/newsApi";
 
 import Sidebar from "./sidebar";
 
@@ -68,44 +70,69 @@ const NewsLink = styled.a`
 `;
 
 const NewsDetailPage = () => {
-    const { category, id } = useParams();
+    const { category, id } = useParams(); // URL에서 category, id 값 가져오기
+    const [newsData, setNewsData] = useState(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(null);
 
-    const newsData = {
-        id: 1,
-        title: "Fed Cuts Interest Rates to 2.5%",
-        content: "The Federal Reserve cut interest rates for the fifth time in six months, lowering the federal funds rate to 2.5%.The Federal Reserve cut interest rates for the fifth time in six months, lowering the federal funds rate to 2.5%.The Federal Reserve cut interest rates for the fifth time in six months, lowering the federal funds rate to 2.5%.The Federal Reserve cut interest rates for the fifth time in six months, lowering the federal funds rate to 2.5%.The Federal Reserve cut interest rates for the fifth time in six months, lowering the federal funds rate to 2.5%.The Federal Reserve cut interest rates for the fifth time in six months, lowering the federal funds rate to 2.5%.",
-        date: "2002-02-21",
-        source: "The New York Times",
-        link: "https://www.nytimes.com/2002/02/21/business/fed-cuts-interest-rates-to-2.5.html"
-    };
+    useEffect(() => {
+        const fetchNewsDetail = async () => {
+            setLoading(true);
+            setError(null);
+            try {
+                console.log("현재 카테고리:", category, "요청한 뉴스 ID:", id);
+                const data = await fetchNewsByCategory(category); // 전체 카테고리 뉴스 목록 가져오기
+                const selectedNews = data.find(news => String(news.id) === id); // 클릭한 뉴스 ID에 해당하는 데이터 찾기
+                
+                if (!selectedNews) {
+                    setError("해당 뉴스를 찾을 수 없습니다.");
+                } else {
+                    setNewsData(selectedNews);
+                }
+            } catch (error) {
+                setError("뉴스 데이터를 불러오는 중 오류가 발생했습니다.");
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchNewsDetail();
+    }, [category, id]);
 
     return (
         <>
             <Sidebar />
             <Container>
-                <Title>{newsData.title}</Title>
-                <DetailBox>
-                    <DetailRow>
-                        <DetailLabel>날짜</DetailLabel>
-                        <DetailValue>{newsData.date}</DetailValue>
-                    </DetailRow>
-                    <DetailRow>
-                        <DetailLabel>출처</DetailLabel>
-                        <DetailValue>{newsData.source}</DetailValue>
-                    </DetailRow>
-                    <DetailRow>
-                        <DetailLabel>내용</DetailLabel>
-                        <DetailValue>{newsData.content}</DetailValue>
-                    </DetailRow>
-                    <DetailRow>
-                        <DetailLabel>뉴스 링크</DetailLabel>
-                        <DetailValue>
-                            <NewsLink href={newsData.link} target="_blank" rel="noopener noreferrer">
-                                {newsData.link}
-                            </NewsLink>
-                        </DetailValue>
-                    </DetailRow>
-                </DetailBox>
+                {loading && <p>로딩 중...</p>}
+                {error && <p style={{ color: "red" }}>{error}</p>}
+
+                {newsData && (
+                    <>
+                        <Title>{newsData.title}</Title>
+                        <DetailBox>
+                            <DetailRow>
+                                <DetailLabel>날짜</DetailLabel>
+                                <DetailValue>{newsData.date}</DetailValue>
+                            </DetailRow>
+                            <DetailRow>
+                                <DetailLabel>출처</DetailLabel>
+                                <DetailValue>{newsData.source}</DetailValue>
+                            </DetailRow>
+                            <DetailRow>
+                                <DetailLabel>내용</DetailLabel>
+                                <DetailValue>{newsData.content}</DetailValue>
+                            </DetailRow>
+                            <DetailRow>
+                                <DetailLabel>뉴스 링크</DetailLabel>
+                                <DetailValue>
+                                    <NewsLink href={newsData.link} target="_blank" rel="noopener noreferrer">
+                                        {newsData.link}
+                                    </NewsLink>
+                                </DetailValue>
+                            </DetailRow>
+                        </DetailBox>
+                    </>
+                )}
             </Container>
         </>
     );

--- a/newspace-frontend/src/pages/news/sidebar.jsx
+++ b/newspace-frontend/src/pages/news/sidebar.jsx
@@ -52,14 +52,14 @@ const AddCategoryButton = styled.div`
     margin-top: auto;
     margin-bottom: 40px;
     padding: 15px;
-    width: 15px;  /* 버튼 크기 조정 */
-    height: 15px; /* 버튼 크기 조정 */
+    width: 15px; 
+    height: 15px;
     display: flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
     background-color: #1D7F81;
-    border-radius: 50px; /* 더 둥글게 조정 */
+    border-radius: 50px; 
     color: white;
     transition: 0.3s ease;
 
@@ -230,6 +230,7 @@ const Sidebar = () => {
         };
     }, [popup]);
 
+    // 카테고리 추가
     const addCategory = () => {
         if (newCategory && selectedIcon) {
             setCategories([...categories, { name: newCategory, icon: selectedIcon }]);


### PR DESCRIPTION
- '/news/키워드'로 리다이렉션하여 키워드별 뉴스 목록 조회
- 뉴스 목록에서 제목 클릭 시 해당 뉴스의 상세 페이지로 이동
- AI 기반 뉴스 데이터 API 연동 완료